### PR TITLE
fix: use generic typevars to define the entities of the repositories

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v1

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,7 +19,6 @@ disallow_untyped_defs = True
 # Required to not have  error: Untyped decorator makes function on fixtures and
 # parametrize decorators
 disallow_untyped_decorators = False
-function_returns_value = False
 
 [mypy-setuptools.*]
 ignore_missing_imports = True

--- a/src/repository_pattern/adapters/fake.py
+++ b/src/repository_pattern/adapters/fake.py
@@ -3,7 +3,7 @@
 import copy
 import logging
 import re
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 from deepdiff import extract, grep
 
@@ -11,10 +11,12 @@ from deepdiff import extract, grep
 from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
 
 from ..exceptions import EntityNotFoundError
-from ..model import Entity
+from ..model import Entity as EntityModel
 from . import AbstractRepository
 
 log = logging.getLogger(__name__)
+
+Entity = TypeVar("Entity", bound=EntityModel)
 
 FakeRepositoryDB = Dict[Type[Entity], Dict[Union[str, int], Entity]]
 
@@ -22,8 +24,8 @@ FakeRepositoryDB = Dict[Type[Entity], Dict[Union[str, int], Entity]]
 class FakeRepository(BaseModel, AbstractRepository):
     """Implement the repository pattern using a memory dictionary."""
 
-    entities: FakeRepositoryDB = Field(default_factory=dict)
-    new_entities: FakeRepositoryDB = Field(default_factory=dict)
+    entities: FakeRepositoryDB[Any] = Field(default_factory=dict)
+    new_entities: FakeRepositoryDB[Any] = Field(default_factory=dict)
 
     def __init__(self, database_url: str = "", **data: Any) -> None:
         """Initialize the repository attributes."""

--- a/src/repository_pattern/adapters/pypika.py
+++ b/src/repository_pattern/adapters/pypika.py
@@ -3,16 +3,18 @@
 import logging
 import os
 import sqlite3
-from typing import Dict, List, Type, Union
+from typing import Dict, List, Type, TypeVar, Union
 
 from pypika import Query, Table
 from yoyo import get_backend, read_migrations
 
 from ..exceptions import EntityNotFoundError
-from ..model import Entity
+from ..model import Entity as EntityModel
 from . import AbstractRepository
 
 log = logging.getLogger(__name__)
+
+Entity = TypeVar("Entity", bound=EntityModel)
 
 
 class PypikaRepository(AbstractRepository):

--- a/tests/cases/repositories.py
+++ b/tests/cases/repositories.py
@@ -3,7 +3,12 @@
 import sqlite3
 from typing import Tuple
 
-from repository_pattern import FakeRepository, FakeRepositoryDB, PypikaRepository
+from repository_pattern import (
+    Entity,
+    FakeRepository,
+    FakeRepositoryDB,
+    PypikaRepository,
+)
 
 from .testers import FakeRepositoryTester, PypikaRepositoryTester
 
@@ -13,7 +18,9 @@ class RepositoryCases:
 
     def case_fake(
         self, repo_fake: FakeRepository
-    ) -> Tuple[FakeRepositoryDB, FakeRepository, FakeRepository, FakeRepositoryTester]:
+    ) -> Tuple[
+        FakeRepositoryDB[Entity], FakeRepository, FakeRepository, FakeRepositoryTester
+    ]:
         """Return the objects to test the FakeRepository.
 
         Returns:

--- a/tests/cases/testers.py
+++ b/tests/cases/testers.py
@@ -64,7 +64,7 @@ class FakeRepositoryTester(AbstractRepositoryTester[FakeRepository]):  # noqa: E
 
     def assert_schema_exists(  # noqa: R0201
         self,
-        database: FakeRepositoryDB,  # noqa: W0613
+        database: FakeRepositoryDB[Entity],  # noqa: W0613
         caplog: LogCaptureFixture,  # noqa: W0613
     ) -> None:
         """Make sure that the repository has a valid schema."""
@@ -72,7 +72,7 @@ class FakeRepositoryTester(AbstractRepositoryTester[FakeRepository]):  # noqa: E
         assert True
 
     def get_entity(  # noqa: R0201
-        self, database: FakeRepositoryDB, entity: Entity
+        self, database: FakeRepositoryDB[Entity], entity: Entity
     ) -> Entity:
         """Get the entity object from the data stored in the repository by it's id."""
         try:
@@ -81,7 +81,7 @@ class FakeRepositoryTester(AbstractRepositoryTester[FakeRepository]):  # noqa: E
             raise EntityNotFoundError() from error
 
     def get_all(  # noqa: R0201
-        self, database: FakeRepositoryDB, entity_model: Type[Entity]
+        self, database: FakeRepositoryDB[Entity], entity_model: Type[Entity]
     ) -> List[Entity]:
         """Get all the entities of type entity_model from the database."""
         try:
@@ -90,7 +90,7 @@ class FakeRepositoryTester(AbstractRepositoryTester[FakeRepository]):  # noqa: E
             raise EntityNotFoundError() from error
 
     def insert_entity(  # noqa: R0201
-        self, database: FakeRepositoryDB, entity: Entity
+        self, database: FakeRepositoryDB[Entity], entity: Entity
     ) -> None:
         """Insert the data of an entity into the repository."""
         try:


### PR DESCRIPTION
When using the repository with custom entity objects subclassed from the
Entity provided by this repo, mypy showed an error because those objects
had attributes that the Entity didn't

<!--
Thank you for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is, try to link it with open issues -->

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
