### PR TITLE
feat: make add idempotent for Fake and Pypika repositories

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 3
       matrix:
@@ -20,9 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Update sqlite
+        run: |
+          python -c 'import sqlite3; print(sqlite3.sqlite_version)'
       - name: Install dependencies
         run: make install
       - name: Test linters

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,8 @@ pip install repository-pattern
 The different repositories share the following operations:
 
 `add`
-: Add an `Entity` object to the repository.
+: Add an `Entity` object to the repository, if it already exist, update the
+    stored attributes.
 
 `delete`
 : Remove an `Entity` object form the repository.

--- a/docs/pypika_repository.md
+++ b/docs/pypika_repository.md
@@ -40,7 +40,9 @@ method.
 
 [`add`][repository_pattern.adapters.pypika.PypikaRepository.add]
 : Appends the `Entity` object to its table by translating its attributes to the
-    columns.
+    columns. If it already exists, use the [upsert
+    statement](https://www.sqlite.org/lang_UPSERT.html) to update it's
+    attributes in the table.
 
 [`delete`][repository_pattern.adapters.pypika.PypikaRepository.delete]
 : Deletes the `Entity` object from its table by searching the row that matches

--- a/tests/cases/entities.py
+++ b/tests/cases/entities.py
@@ -28,6 +28,7 @@ class AuthorFactory(factory.Factory):  # type: ignore
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
     country = factory.Faker("country")
+    rating = factory.Faker("pyint")
 
     class Meta:
         """Define the entity model object to use."""
@@ -42,6 +43,7 @@ class BookFactory(factory.Factory):  # type: ignore
     title = factory.Faker("sentence")
     summary = factory.Faker("text")
     released = factory.Faker("date_time")
+    rating = factory.Faker("pyint")
 
     class Meta:
         """Define the entity model object to use."""
@@ -55,6 +57,7 @@ class GenreFactory(factory.Factory):  # type: ignore
     id_ = factory.Faker("pyint")
     name = factory.Faker("name")
     description = factory.Faker("sentence")
+    rating = factory.Faker("pyint")
 
     class Meta:
         """Define the entity model object to use."""

--- a/tests/cases/model.py
+++ b/tests/cases/model.py
@@ -12,6 +12,7 @@ class Author(Entity):
     first_name: str
     last_name: str
     country: str
+    rating: int
 
 
 class Book(Entity):
@@ -21,6 +22,7 @@ class Book(Entity):
     title: str
     summary: str
     released: datetime
+    rating: int
 
 
 class Genre(Entity):
@@ -29,3 +31,4 @@ class Genre(Entity):
     id_: int
     name: str
     description: str
+    rating: int

--- a/tests/migrations/pypika/0001_initial_schema.py
+++ b/tests/migrations/pypika/0001_initial_schema.py
@@ -9,6 +9,7 @@ steps = [
         "first_name VARCHAR(20), "
         "last_name VARCHAR(20), "
         "country VARCHAR(20), "
+        "rating INT, "
         "PRIMARY KEY (id))",
         "DROP TABLE author",
     ),
@@ -18,6 +19,7 @@ steps = [
         "title VARCHAR(20), "
         "summary VARCHAR(255), "
         "released DATETIME, "
+        "rating INT, "
         "PRIMARY KEY (id))",
         "DROP TABLE book",
     ),
@@ -26,6 +28,7 @@ steps = [
         "id INT, "
         "name VARCHAR(20), "
         "description VARCHAR(255), "
+        "rating INT, "
         "PRIMARY KEY (id))",
         "DROP TABLE genre",
     ),


### PR DESCRIPTION
Adding an Entities is now idempotent, and if the entity already exist in
the repository, it will update it's attributes.

<!--
Thank you for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is, try to link it with open issues -->

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
